### PR TITLE
:construction:  Fix error when client is disconnected to server

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "client/Client.hpp"
+#include "NetworkException.hpp"
 #include <iostream>
 #include <thread>
 
@@ -24,11 +25,15 @@ int main(int argc, char* argv[])
     try {
         Network::Client client(host, UDP_port, TCP_port);
         std::cout << "Client trying to connect to server..." << std::endl;
-        client.connect();
+        try {
+            client.connect();
+        } catch (NetworkException &e) {
+            return 84;
+        }
         std::cout << "Client connected to server" << std::endl;
         const std::vector message = { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!' };
 
-        while(true){
+        while(client.is_alive()) {
             client.add_to_send_queue(message);
             std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Add a sleep interval
 

--- a/network/client/Client.cpp
+++ b/network/client/Client.cpp
@@ -57,10 +57,7 @@ void Network::Client::connect()
 
     // Run the io_context in a separate thread to keep the client open
     _io_thread = std::thread([this]() {
-        while (_is_alive) {
-            _io_context.run();
-            _io_context.restart();
-        }
+        _io_context.run();
     });
 }
 
@@ -153,26 +150,25 @@ size_t Network::Client::get_size_recv_queue()
     return _recv_queue.size();
 }
 
+bool Network::Client::is_alive() const
+{
+    return _is_alive;
+}
 
 //---------------------------------------Stop method---------------------------------------
 
 void Network::Client::stop()
 {
-    if(_tcp_socket.is_open()) {
-        asio::write(_tcp_socket, asio::buffer("exit\n", sizeof(_id)));
-        _tcp_socket.close();
-    }
-    if (_udp_socket.is_open()) {
-        _udp_socket.close();
-    }
-    _io_context.stop();
     _is_alive = false;
 }
 
 Network::Client::~Client()
 {
+    std::cout << "Client destructor" << std::endl;
     _io_context.stop();
+
     if (_io_thread.joinable()) {
         _io_thread.join();
     }
+    exit(0); //todo: remove this
 }

--- a/network/client/Client.hpp
+++ b/network/client/Client.hpp
@@ -133,6 +133,14 @@ namespace Network {
          */
         void stop() override;
 
+        /**
+         * @brief Indicates if the client is alive
+         * @return True if the client is alive, false otherwise
+         * @version 0.1.0
+         * @since 0.1.0
+         */
+        bool is_alive() const;
+
     private:
 
         /**

--- a/network/client/Client.hpp
+++ b/network/client/Client.hpp
@@ -143,13 +143,13 @@ namespace Network {
 
     private:
 
-        /**
-         * @brief Sends data to the server with udp socket
-         * @param data The data to send
-         * @param handler The handler to call when the data is sent
-         * @version 0.1.0
-         * @since 0.1.0
-         */
+       /**
+        * @brief Sends data to the server with udp socket
+        * @param data The data to send
+        * @param handler The handler to call when the data is sent
+        * @version 0.1.0
+        * @since 0.1.0
+        */
         void send_udp_data_loop();
 
         std::string _host; ///< The host address

--- a/network/server/Server.cpp
+++ b/network/server/Server.cpp
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <iostream>
 #include <asio.hpp>
-#include <codecvt>
 
 //-------------------------------------Constructor------------------------------------------
 Network::Server::Server(unsigned short TCP_port, unsigned short UDP_port)


### PR DESCRIPTION
This pull request includes several changes to improve error handling, client lifecycle management, and code cleanup in the network client and server files. The most important changes include adding an exception handler for the client connection, introducing a method to check if the client is alive, and cleaning up the client stop method.

Error handling improvements:

* [`client/main.cpp`](diffhunk://#diff-0bd51ef4d3e948a95ca277af0747d450e561ef0a1c781760b2b9e440bb9e9f88R28-R36): Added an exception handler for `NetworkException` during the client connection process to handle connection errors gracefully.

Client lifecycle management:

* [`network/client/Client.cpp`](diffhunk://#diff-d922e2cd204a680705d7536054e6d5497bc7ce597a7926b83a88e1471a75a100R153-R173): Introduced the `is_alive` method to check if the client is alive, and modified the client loop to use this method instead of an infinite loop. [[1]](diffhunk://#diff-d922e2cd204a680705d7536054e6d5497bc7ce597a7926b83a88e1471a75a100R153-R173) [[2]](diffhunk://#diff-0bd51ef4d3e948a95ca277af0747d450e561ef0a1c781760b2b9e440bb9e9f88R28-R36)
* [`network/client/Client.hpp`](diffhunk://#diff-3bfb5ab617684656916943ad4087c8a5a538ab181b85786d3b5d54d0ca2021faR136-R143): Added the `is_alive` method declaration to the client header file.

Code cleanup:

* [`network/client/Client.cpp`](diffhunk://#diff-d922e2cd204a680705d7536054e6d5497bc7ce597a7926b83a88e1471a75a100R153-R173): Cleaned up the `stop` method by removing redundant socket closure code and added a debug print statement in the destructor.
* [`network/server/Server.cpp`](diffhunk://#diff-f7f1159faf18ca0fb56daf1c91236d875650215bd8da82cf5d1a363c09a4164bL13): Removed an unused include directive for `<codecvt>`.