### PR TITLE
:construction: Add a bash script to build on linux (EPI-125)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.28)
 
 project(R-Type-Reborn
         LANGUAGES CXX)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Set script to exit on any errors.
+set -e
+
+# Variables for dependency directories
+BUILD_DIR="build"
+CONAN_PROFILE="default"
+
+# Function to print info messages in yellow color
+info() {
+  echo -e "\033[1;33m[info] $1\033[0m"
+}
+
+# Step 1: Install Conan if not already installed
+info "Checking if Conan is installed..."
+if ! command -v conan &> /dev/null
+then
+    info "Conan not found, installing Conan..."
+    pip install conan
+fi
+
+# Step 2: Create build directory if it does not exist
+info "Creating build directory if it does not exist..."
+if [ ! -d "$BUILD_DIR" ]; then
+  info "Creating build directory..."
+  mkdir -p "$BUILD_DIR"
+fi
+
+# Step 3: Run Conan to install missing dependencies
+info "Changing to build directory..."
+cd "$BUILD_DIR"
+
+info "Ensuring Conan profile is available..."
+if ! conan profile list | grep -q "$CONAN_PROFILE"; then
+    info "Creating Conan profile: $CONAN_PROFILE"
+    conan profile detect --name "$CONAN_PROFILE"
+fi
+
+info "Installing dependencies with Conan..."
+conan install .. --build=missing --profile="$CONAN_PROFILE" -g CMakeDeps -g CMakeToolchain
+
+# Step 4: Run CMake to configure the build
+info "Running CMake to configure the build..."
+cmake -S .. -B . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_PREFIX_PATH="." -DCMAKE_BUILD_TYPE=Release
+
+# Step 5: Build the project with CMake
+info "Building the project with CMake..."
+cmake --build . --target r-type_server
+
+# Step 5: Build the project with CMake
+info "Building the project with CMake..."
+cmake --build . --target r-type_client


### PR DESCRIPTION
This pull request includes changes to the `CMakeLists.txt` file and adds a new build script for Linux. The most important changes involve adjusting the CMake version requirement and introducing a comprehensive build script to streamline the build process on Linux systems.

Build process improvements:

* [`build-linux.sh`](diffhunk://#diff-eba01c43adcd379f850b6a43cff8305468b88033fb32fcebe8dec66f3793a255R1-R53): Added a new build script to automate the build process on Linux. This script checks for Conan installation, creates a build directory, installs dependencies, configures the build with CMake, and builds the project targets `r-type_server` and `r-type_client`.

CMake configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1): Updated the minimum required CMake version from 3.29 to 3.28.