### PR TITLE
:construction: Add a script to build the project on linux (EPI-125)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.28)
 
 project(R-Type-Reborn
         LANGUAGES CXX)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Set script to exit on any errors.
+set -e
+
+# Variables for dependency directories
+BUILD_DIR="build"
+CONAN_PROFILE="default"
+
+# Function to print info messages in yellow color
+info() {
+  echo -e "\033[1;33m[info] $1\033[0m"
+}
+
+# Step 1: Install Conan if not already installed
+info "Checking if Conan is installed..."
+if ! command -v conan &> /dev/null
+then
+    info "Conan not found, installing Conan..."
+    pip install conan
+fi
+
+# Step 2: Create build directory if it does not exist
+info "Creating build directory if it does not exist..."
+if [ ! -d "$BUILD_DIR" ]; then
+  info "Creating build directory..."
+  mkdir -p "$BUILD_DIR"
+fi
+
+# Step 3: Run Conan to install missing dependencies
+info "Changing to build directory..."
+cd "$BUILD_DIR"
+
+info "Ensuring Conan profile is available..."
+if ! conan profile list | grep -q "$CONAN_PROFILE"; then
+    info "Creating Conan profile: $CONAN_PROFILE"
+    conan profile detect --name "$CONAN_PROFILE"
+fi
+
+info "Installing dependencies with Conan..."
+conan install .. --build=missing --profile="$CONAN_PROFILE" -g CMakeDeps -g CMakeToolchain
+
+# Step 4: Run CMake to configure the build
+info "Running CMake to configure the build..."
+cmake -S .. -B . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_PREFIX_PATH="." -DCMAKE_BUILD_TYPE=Release
+
+# Step 5: Build the project with CMake
+info "Building the project with CMake..."
+cmake --build . --target r-type_server
+
+# Step 5: Build the project with CMake
+info "Building the project with CMake..."
+cmake --build . --target r-type_client

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -44,10 +44,13 @@ conan install .. --build=missing --profile="$CONAN_PROFILE" -g CMakeDeps -g CMak
 info "Running CMake to configure the build..."
 cmake -S .. -B . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_PREFIX_PATH="." -DCMAKE_BUILD_TYPE=Release
 
-# Step 5: Build the project with CMake
-info "Building the project with CMake..."
-cmake --build . --target r-type_server
+# Step 5: Detect number of available threads for parallel build
+NUM_THREADS=$(nproc --all)
+info "Number of threads available for build: $NUM_THREADS"
 
-# Step 5: Build the project with CMake
-info "Building the project with CMake..."
-cmake --build . --target r-type_client
+# Step 6: Build the project with CMake
+info "Building the server project with CMake..."
+cmake --build . --target r-type_server -- -j "$NUM_THREADS"
+
+info "Building the client project with CMake..."
+cmake --build . --target r-type_client -- -j "$NUM_THREADS"


### PR DESCRIPTION
This pull request includes changes to the build configuration and setup scripts. The most important changes include updating the minimum required CMake version and adding a new build script for Linux.

Build configuration updates:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1): Downgraded the minimum required CMake version from 3.29 to 3.28.

New build script:

* [`build-linux.sh`](diffhunk://#diff-eba01c43adcd379f850b6a43cff8305468b88033fb32fcebe8dec66f3793a255R1-R56): Added a new shell script to automate the build process on Linux. This script checks for Conan installation, sets up the build directory, installs dependencies, configures the build with CMake, and builds the server and client projects in parallel.