### PR TITLE
🪟  Fix the network lib for windows (EPI-164)

### DIFF
--- a/network/client/Client.cpp
+++ b/network/client/Client.cpp
@@ -54,8 +54,6 @@ void Network::Client::connect()
     receive_udp_data();
     receive_tcp_data();
 
-    //send_udp_data_loop(); //Todo fix me
-
     // Run the io_context in a separate thread to keep the client open
     _io_thread = std::thread([this]() {
         _io_context.run();

--- a/network/client/Client.cpp
+++ b/network/client/Client.cpp
@@ -46,7 +46,8 @@ void Network::Client::connect()
     _udp_socket.connect(_endpoint);
 
     // Write through the TCP the client endpoint
-    asio::write(_tcp_socket, asio::buffer(&_udp_socket.local_endpoint(), sizeof(asio::ip::udp::endpoint)));
+    asio::ip::udp::endpoint local_endpoint = _udp_socket.local_endpoint();
+    asio::write(_tcp_socket, asio::buffer(&local_endpoint, sizeof(asio::ip::udp::endpoint)));
 
     std::cout << "Connected in UDP, port " << _UDP_PORT << '\n';
 

--- a/network/client/Client.cpp
+++ b/network/client/Client.cpp
@@ -44,10 +44,12 @@ void Network::Client::connect()
     _endpoint = asio::ip::udp::endpoint(asio::ip::address::from_string(_host), _UDP_PORT);
     _udp_socket.bind(asio::ip::udp::endpoint(asio::ip::udp::v4(), 0));
     _udp_socket.connect(_endpoint);
-    _udp_socket.send(asio::buffer("Hello", 5));
+
+    // Write through the TCP the client endpoint
+    asio::write(_tcp_socket, asio::buffer(&_udp_socket.local_endpoint(), sizeof(asio::ip::udp::endpoint)));
+
     std::cout << "Connected in UDP, port " << _UDP_PORT << '\n';
 
-    asio::write(_tcp_socket, asio::buffer("Hello\n", 6));
     receive_udp_data();
     receive_tcp_data();
 
@@ -166,7 +168,6 @@ void Network::Client::stop()
 
 Network::Client::~Client()
 {
-    std::cout << "Client destructor" << '\n';
     _io_context.stop();
 
     if (_io_thread.joinable()) {

--- a/network/server/Server.cpp
+++ b/network/server/Server.cpp
@@ -43,11 +43,11 @@ void Network::Server::connect_new_client(RType::Server *server) {
             auto clientConnectedMessage = std::make_shared<ClientConnected>("Client connected with id: " + std::to_string(client_id), client_id);
             std::cout << "TCP client, id: " << client_id << '\n';
 
-            // Wait for UDP connection from the same client
+            // Send the client id trought the tcp socket
             asio::write(*_tcp_sockets[client_id], asio::buffer(&client_id, sizeof(client_id)));
+            // Read  the client endpoint trought the tcp socket
+            asio::read(*_tcp_sockets[client_id], asio::buffer(&_remote_endpoint, sizeof(_remote_endpoint)));
 
-            _socket.receive_from(asio::buffer(_recv_tcp_buffer.prepare(1024)), _remote_endpoint);
-            _recv_tcp_buffer.commit(1024); // Commit the prepared size
             _clients[client_id] = _remote_endpoint;
             std::cout << "UDP client, id: " << client_id << '\n';
 


### PR DESCRIPTION
This pull request includes several important changes to the network client and server code to improve the connection handling between TCP and UDP. The most significant changes involve modifying how client endpoints are communicated and removing unnecessary logging.

### Changes to connection handling:

* [`network/client/Client.cpp`](diffhunk://#diff-d922e2cd204a680705d7536054e6d5497bc7ce597a7926b83a88e1471a75a100L47-L50): Updated the `connect` method to send the client endpoint through the TCP socket instead of sending a simple "Hello" message. This ensures that the server can correctly identify and communicate with the client over UDP.
* [`network/server/Server.cpp`](diffhunk://#diff-f7f1159faf18ca0fb56daf1c91236d875650215bd8da82cf5d1a363c09a4164bL46-L50): Modified the `connect_new_client` method to send the client ID through the TCP socket and read the client endpoint from the TCP socket. This change allows the server to correctly map the client ID to the UDP endpoint.

### Code cleanup:

* [`network/client/Client.cpp`](diffhunk://#diff-d922e2cd204a680705d7536054e6d5497bc7ce597a7926b83a88e1471a75a100L169): Removed an unnecessary log message from the `Client` destructor.